### PR TITLE
remove unnecessary hardcoding of /bin/sh

### DIFF
--- a/sysctl.el
+++ b/sysctl.el
@@ -40,8 +40,7 @@
 
 (defun sysctl--run-command (args)
   "Run shell commands ARGS and return output as a string, only exists as a TRAMP issue work around."
-  (let ((shell-file-name "/bin/sh"))
-    (shell-command-to-string args)))
+  (shell-command-to-string args))
 
 (defun sysctl-run (args)
   "Run `sysctl' with the ARGS arguments, run with root if AS-ROOT is non-nil."


### PR DESCRIPTION
Hello,

I was very glad to see this awesome package show up in the package list! I was surprised that it failed, and after a little bit of digging, on my Arch Linux install, I saw this result from `sysctl--run-command`:
```
"sh: cannot set terminal process group (-1): Inappropriate ioctl for device
sh: no job control in this shell
Linux
"
```

After making the diff I have here, this problem went away. The most relevant background I can find is this stackoverflow question: https://stackoverflow.com/questions/11821378/what-does-bashno-job-control-in-this-shell-mean

You refer to a "TRAMP issue work around" in this method. Was the shell filename hardcoding the solution to that?

I would have otherwise assumed that if your personal machine was failing, you would either set `/bin/sh` as `shell-file-name` in `customize-variable`, or possibly make use of `add-function` to perform the hardcoding you're looking for if it needs to only work for that case.

Would that fix work for you?

Thanks again for the lovely package!